### PR TITLE
Version 1.0.1 cannot be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from __future__ import unicode_literals
 
 import os
 import re
-import sys
 
+from setuptools import find_packages
 from setuptools import setup
 
 root_dir = os.path.abspath(os.path.dirname(__file__))
@@ -39,7 +39,7 @@ setup(
     keywords=['workflow', 'state machine', 'automaton'],
     url="https://github.com/rbarrois/xworkflows",
     download_url="https://pypi.python.org/pypi/xworkflows/",
-    packages=['xworkflows'],
+    packages=find_packages(),
     setup_requires=[
         'setuptools>=0.8',
     ],


### PR DESCRIPTION
Since 6efd1a518838dba553b213a457e3b0b493378713 (included in v 1.0.1 release), xworkflows cannot be installed anymore:

```
$ python setup.py build
running build
running build_py
Traceback (most recent call last):
  File "setup.py", line 55, in <module>
    test_suite='tests',
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/build.py", line 128, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/damien/env/xw/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/command/build_py.py", line 91, in run
    self.build_packages()
  File "/usr/lib/python2.7/distutils/command/build_py.py", line 372, in build_packages
    self.build_module(module, module_file, package)
  File "/home/damien/env/xw/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/command/build_py.py", line 108, in build_module
    outfile, copied = _build_py.build_module(self, module, module_file, package)
  File "/usr/lib/python2.7/distutils/command/build_py.py", line 333, in build_module
    "'package' must be a string (dot-separated), list, or tuple")
TypeError: 'package' must be a string (dot-separated), list, or tuple
```

Using `setuptools.find_packages()` solves the issue.
