### PR TITLE
`compat.is_callable` raises AttributeError for old Python 2.7 classes

### DIFF
--- a/src/xworkflows/compat.py
+++ b/src/xworkflows/compat.py
@@ -23,4 +23,8 @@ else:
 
 
 def is_callable(var):
-    return isinstance(var, collections.Callable)
+    try:
+        return isinstance(var, collections.Callable)
+    except AttributeError:
+        return False
+


### PR DESCRIPTION
Make `compat.is_callable` resilient to Python 2.7 classes that don't inherit from `object`.

`isinstance` calls `var.__mro__`. A Python 2.7 class that doesn't inherit from `object` has no `__mro__` attribute. The `django-concurrency` package, for example, adds an old style Python 2.7 class to the Django model, so `isinstance` raises "AttributeError: class ConcurrencyOptions has no attribute '__mro__'".